### PR TITLE
Smarter cache time for GitHub calls

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -32,8 +32,10 @@ function cleanupPinnedRepos(data: PinnedReposResponse) {
 export async function load(event) {
 	const data = await github.graphql<PinnedReposResponse>(pinnedReposQuery);
 
+	// Cache using Cloudflare's cache Headers API
+	// https://developers.cloudflare.com/workers/runtime-apis/cache/#headers
 	event.setHeaders({
-		'Cache-Control': 'max-age=600'
+		'Cache-Control': 'public, max-age=15, stale-while-revalidate=5'
 	});
 
 	return {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -34,8 +34,10 @@ export async function load(event) {
 
 	// Cache using Cloudflare's cache Headers API
 	// https://developers.cloudflare.com/workers/runtime-apis/cache/#headers
+	// Usage limits: 5000 points per hour -> aprox 12 requests second
+	// https://docs.github.com/en/graphql/overview/resource-limitations#returning-a-calls-rate-limit-status
 	event.setHeaders({
-		'Cache-Control': 'public, max-age=15, stale-while-revalidate=5'
+		'Cache-Control': 'public, max-age=15, stale-while-revalidate=3'
 	});
 
 	return {


### PR DESCRIPTION
Quiero que el cache no sea tan grande (que dura pocos segundos), pero que a la vez no pueda acabarse el límite de consultas. Falta ver si realmente está funcionando o si se puede cachear solo el call a GitHub.